### PR TITLE
MainMenu level created.

### DIFF
--- a/Content/CombatFrameworkContent/GameFramework/BP_GameMode.uasset
+++ b/Content/CombatFrameworkContent/GameFramework/BP_GameMode.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61eee0a28cfc29c1a798880fe4e3c2d04d67e59dcd1c075c231886e65acd6581
-size 2620

--- a/Content/CombatFrameworkContent/GameFramework/BP_MainGameMode.uasset
+++ b/Content/CombatFrameworkContent/GameFramework/BP_MainGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92d41bb5a1c24f1b6d9b09571d40c081136664c8d986ee963edbd3c45ac2fb17
-size 20898
+oid sha256:7d939ef5cc14606305b8280324bd3424ceb4cf9ac03b57a1fd66568be926b862
+size 20902

--- a/Content/CombatFrameworkContent/GameFramework/BP_MainMenuGameMode.uasset
+++ b/Content/CombatFrameworkContent/GameFramework/BP_MainMenuGameMode.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b48caffcf6dcaef2e18bd5609add2e6727c982f6ce22eb8881ab6f67e383553c
+size 29022

--- a/Content/CombatFrameworkContent/Levels/GameLevels/LV_Main.umap
+++ b/Content/CombatFrameworkContent/Levels/GameLevels/LV_Main.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e7b634645a36d075da219a7761aa918637bf158fc670b4ca981c33cf25d8773
+size 20065

--- a/Content/CombatFrameworkContent/Levels/MenuLevels/LV_MainMenu.umap
+++ b/Content/CombatFrameworkContent/Levels/MenuLevels/LV_MainMenu.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1cc049882e7de5d5f5bcf2d43d98ac34553b9e5128a523443c3cda0a21317d1
-size 6609
+oid sha256:14620de5a75759aa469252457cb2f28ab9579f797181afa521fad90b16ae1392
+size 19977

--- a/Content/CombatFrameworkContent/Levels/MenuLevels/LV_MainMenu.umap
+++ b/Content/CombatFrameworkContent/Levels/MenuLevels/LV_MainMenu.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1cc049882e7de5d5f5bcf2d43d98ac34553b9e5128a523443c3cda0a21317d1
+size 6609

--- a/Content/CombatFrameworkContent/Widgets/InGame/WBP_MainPauseMenu.uasset
+++ b/Content/CombatFrameworkContent/Widgets/InGame/WBP_MainPauseMenu.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60515f1b0697eaf406e69ff692179373165988a445fa5582cadbe536283cc6ad
+size 50675

--- a/Content/CombatFrameworkContent/Widgets/InGame/W_MainPauseMenu.uasset
+++ b/Content/CombatFrameworkContent/Widgets/InGame/W_MainPauseMenu.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:860419042a303723f4165e8a2cb9c7912a01c8eec264614d5c4fe8a13040dfca
-size 50749

--- a/Content/CombatFrameworkContent/Widgets/Menus/WBP_MainMenu.uasset
+++ b/Content/CombatFrameworkContent/Widgets/Menus/WBP_MainMenu.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50ddf978213129372c4e23afc7a2e85be87e92770c9174e1f02778868308ea4e
+size 45519

--- a/Content/ThirdPerson/Maps/ThirdPersonMap.umap
+++ b/Content/ThirdPerson/Maps/ThirdPersonMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a565563b0bb070b587e18edf2284867983f6df3401fde69ae0e7af1158436cf3
-size 19384
+oid sha256:b0888bcb9cd26822d6503666bc56f6943d7ce47db87d265f927a92d6048687bc
+size 20195

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/0/92/FVALRG88PKTHQ158WDK3QW.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/0/92/FVALRG88PKTHQ158WDK3QW.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b980b15abd2de456859fc394fa115a5a21f5263079cd374c942d813e0ca41b33
+size 4981

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/0/V9/RP8JQ7EYY4YCZGX1EM31I7.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/0/V9/RP8JQ7EYY4YCZGX1EM31I7.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c205b5d8e27c85441fd81207e10c92cf880ae43d0f61dc8a4ee4fc18f57799ae
+size 4370

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/KS/22WV4K0052005WOVNPG3SX.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/KS/22WV4K0052005WOVNPG3SX.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b3e88f93597409619cc90b2a4cbb5d430a51ead4ed86542ec4a9ff04e0550a5
+size 4370

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/UF/XFL29B5NQLG5DJ12WJ8HHH.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/UF/XFL29B5NQLG5DJ12WJ8HHH.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47bab0bf3f1b09e413005a5e9dd1a2c586081d3777d2c0f0f2c5f0414f645a38
+size 2273

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/UY/S7PY7U4BSB1XFQ9NWXPOPG.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/UY/S7PY7U4BSB1XFQ9NWXPOPG.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13dd58c5b09364eea1cde8a1b210996d6172d2d96ede003eaaffd45661056d55
+size 3846

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/2/TF/E46M3FD0I3PC8UV9UWV19B.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/2/TF/E46M3FD0I3PC8UV9UWV19B.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620ae93204d6b6a9332f04cca9409c1af32ee67655ddf5b50f17866f2debc630
+size 4392

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/2/VV/VIA8U9QBS0S308TPRR473Y.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/2/VV/VIA8U9QBS0S308TPRR473Y.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cceca0c9c439c4d3e3e16619596d60f9916bd859f6f25ce59c47a328014cac2e
+size 4839

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/AG/JLPKURJ109HY677B3584VN.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/AG/JLPKURJ109HY677B3584VN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e729abee136706287e01652928e5516f131025890eed43efba2406ad3bdba8
+size 4544

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/AJ/KW97QNHS3UGRVZ49M6FGXK.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/AJ/KW97QNHS3UGRVZ49M6FGXK.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14c6a0f5751aed5b53316681399ba77e7b903c748da67a16c14fee16127d3e61
+size 4723

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/B5/YDO8JAO3YSG3T96P7OVCJN.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/B5/YDO8JAO3YSG3T96P7OVCJN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31693941b18d69089dccad39a3ea50b23fb6e8432412669015dce43d839611d5
+size 4482

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/EZ/P1MWINU9HMVJWQC3376974.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/3/EZ/P1MWINU9HMVJWQC3376974.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8ce478f03187ac9a18ec19fb5a73fc0b19bbe2abc1b583a73133f69dfa20b65
+size 4364

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/0D/NY7NP5YRSGPM6FABE6830I.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/0D/NY7NP5YRSGPM6FABE6830I.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a76c233d4737be482ae2ba9f424030c7da0674f4e1ed71495b8be479e738752
+size 3637

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/3V/13G62YVDS0M705JGSTMQ31.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/3V/13G62YVDS0M705JGSTMQ31.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4f36732168201173524fc1fcb91370f9e8195d2449bc7faab8b185154b15b5d
+size 6091

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/CU/YBDT1DDX9DE8VK0OAXNE4P.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/4/CU/YBDT1DDX9DE8VK0OAXNE4P.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ada111f8e05e2d79d1a6328633a631658ff7a498e952e2233c9a72b98b3d77d5
+size 4430

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/9M/IJQSEV1D83O78AVBLD23ER.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/9M/IJQSEV1D83O78AVBLD23ER.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59a09f399eeca398de3fb8b2d27ca7a23aac0a5349091c212588067ebddc3126
+size 3635

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/Y8/0NFHEVQSDK0T0C82SSTLZR.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/Y8/0NFHEVQSDK0T0C82SSTLZR.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:894737bab05ebeb7db9669929ad7ed58d43dd5ddd52fdb4b7ce48eb4a012983f
+size 4482

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/YP/N6L65X60VSUXT290Q7277S.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/YP/N6L65X60VSUXT290Q7277S.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d373e33e0c007edc63eb7e12e2d8c8d82694d56c4a6390b9e181b7d09ef60001
+size 4366

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/HI/5NCNMZ7B3LJMLI5OMSBU17.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/HI/5NCNMZ7B3LJMLI5OMSBU17.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f43b9704faacc2ee8705679685af80fac05d7f583c62c507b068965f1bb0a030
+size 4544

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/HZ/I1L57U0VK1DKIWUEE2G5XW.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/HZ/I1L57U0VK1DKIWUEE2G5XW.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7be521a0d3f684397794d95b9cef957a678968eebd38f194d73ccf1d3cec9517
+size 4370

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/IV/O9LYTLKR45X5M2JEJQ3UBQ.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/IV/O9LYTLKR45X5M2JEJQ3UBQ.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae7f1d515bb8d68a9715e2fcb9ab5b2c3fcc0c37cfd054d27cf34e266662c343
+size 4003

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/TP/HPF9EGIVFMJAPDNWU5WNMA.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/TP/HPF9EGIVFMJAPDNWU5WNMA.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01493bf144457092b8060bb024b7a5c91f3a3ae06e4787c58523e812822e8653
+size 12478

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/ZB/JC1V2Y2N1U7TQTSU3PK29E.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/6/ZB/JC1V2Y2N1U7TQTSU3PK29E.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fff8b204c4b559f9ea0a65f5803ff77fe34bef49fb0908fa5317d2c4f922c700
+size 5262

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/C1/9560LL2Y7LF075VTQ6HCNY.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/C1/9560LL2Y7LF075VTQ6HCNY.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e8744ab580c17d98687aa4665fbb1687636f5b7a8f9e22c42a0b03dfbc5c347
+size 4542

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/F9/K7RJR9J64ITL4YMJ1AF9E5.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/F9/K7RJR9J64ITL4YMJ1AF9E5.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d579739e3058470c9d3b1234b19ad13ea7b9fc5b109f80f412e914d0c45779f9
+size 4484

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/M4/66FCGT8NFYQRQP1DFIAVZ5.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/M4/66FCGT8NFYQRQP1DFIAVZ5.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4a31049c13d3bb9a9992ee90b288705abdae0cae79ca30603c86d89a932539d
+size 4368

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/0M/OK0WFRPDUGHCL3OD5FHDQ9.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/0M/OK0WFRPDUGHCL3OD5FHDQ9.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a11877ea78536586e5a5fe301e82fa93deaf1d902f433ca686ab05e75817a2c
+size 4480

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/JN/RERRHBPNO4M8H0SZNAT4UC.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/JN/RERRHBPNO4M8H0SZNAT4UC.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c60152c8f33ba816085b009a36bff8a363a44da42233ac1b206fd5864e05af4
+size 4368

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/Z2/3ZIQP1A6J9OCGYP0SOG1AU.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/9/Z2/3ZIQP1A6J9OCGYP0SOG1AU.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3053976c7f404675a5b20c09eb3c8b484b6e5f5fdd3ea9ef441a796ab7dd2bf5
+size 4839

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/A/ON/YHN2L9968FPZDUPIAEKITP.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/A/ON/YHN2L9968FPZDUPIAEKITP.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a17cf6712728cc5c3a68b6989c8037cf48d162d126ab8bd0c2e85e6e631cc5c3
+size 4368

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/0J/30WLQ42RHY6UNHY8Z2S8UU.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/0J/30WLQ42RHY6UNHY8Z2S8UU.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e53e2365f4fba6b85f2e2b77555de47611f6b87e41a21e2d3504499c5e50825
+size 4458

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/17/D67NY5XCW642F4YRHLZEA7.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/17/D67NY5XCW642F4YRHLZEA7.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:088ed67ab73842e4d4ec66a8b6f30e110a1a50fb3c101b39475f0b86d04467d8
+size 4368

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/8S/8BND1LYE945ATUARFUZXS0.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/8S/8BND1LYE945ATUARFUZXS0.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eed890a82d03eb7a8d67c128b3bf1e4e7881ed120b4d6ad915599d4271d9770
+size 4542

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/OY/9AOH83GEUIYPPAGWS7GDUQ.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/OY/9AOH83GEUIYPPAGWS7GDUQ.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:726f5c9192c171f437fbf45b37e692b6334d171e4a31ddca8a5d693ab291e963
+size 2390

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/C/Q3/HZT40G242MVCSG0VPG5YFZ.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/C/Q3/HZT40G242MVCSG0VPG5YFZ.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2bffe064d60283c70c2a4e584cd6fe43300116a1ccab6fa2a02503bcc0b97a2
+size 4428

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/C/XG/LKAGBFJ3OOUPQPROX34QWY.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/C/XG/LKAGBFJ3OOUPQPROX34QWY.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69893d8fb634fa4d56938f2bca79d76135d9ac38049c0640c87f19f73e3ca0d8
+size 3730

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/8O/JBUZTSXQAL692RHYWXC27N.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/8O/JBUZTSXQAL692RHYWXC27N.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7a4f4aaed5035268d5214719d35c056f3a563664fb5a0578738b24588016ee8
+size 4480

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/C8/C9VW2PLO8DCJS2LVTOO1AB.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/C8/C9VW2PLO8DCJS2LVTOO1AB.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf8c77e7737795a0dab6b8684451e4cbb60dc88f33ce2894deba2934e77930bf
+size 4544

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/60/T7YPCO6Y6Z6HP43BVT204G.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/60/T7YPCO6Y6Z6HP43BVT204G.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6391389d7b4612e96f8c9803ffebdd44451fbd2d9a1b397e5470623f7b2419c
+size 4422

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/FT/EH16FBDQNFE1BZI7OJISW7.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/FT/EH16FBDQNFE1BZI7OJISW7.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00206431ac052ef8fea4f9f48e7224138cb719f0507e162aa439cc4f9ae916fd
+size 4542

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/HF/MGB415TXNKJ1QHM6BT001Q.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/HF/MGB415TXNKJ1QHM6BT001Q.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1d7df5090ca242505beeda39bb8d8ff6df93595fbee14aa6bb92cef9a1a0291
+size 4268

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/O2/U9RKI1WKGJ32T9EQQ3G858.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/LV_Main/E/O2/U9RKI1WKGJ32T9EQQ3G858.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14c76b28d8604b190eeb140ad8d9b0e10c8529e930aad88936c663d2c7dcf653
+size 4542

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/A7/2XJFIVFRXI1QXODVF5B4H1.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/A7/2XJFIVFRXI1QXODVF5B4H1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb715913d24a2043ac39e2e61d7b11c47a461fa48a169c015e44fec766aa2a5c
+size 4386

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/AX/EHNYU7LCJ4PU1P38TS0EWT.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/AX/EHNYU7LCJ4PU1P38TS0EWT.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e00b123818b2c82cadc0eef9aa8bbeb23101c067b64758475ebbd70e9aeef021
+size 4560

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/HF/RCHIG5UBQ3QEHA8U94LXQ9.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/HF/RCHIG5UBQ3QEHA8U94LXQ9.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:218d743d3e0eab68193cff9decfbe9f8d1811e583a463e36dce37c824b30b931
+size 6107

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/RX/EMYXUSL32FJDTNUXG1RV4B.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/RX/EMYXUSL32FJDTNUXG1RV4B.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f398e65813ec02b5312aa05eed9215e3671903272e2c4465dba4bff85c3c1f51
+size 3862

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/ZB/YGOALYY8NVLMYBYGCMWBE9.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/ZB/YGOALYY8NVLMYBYGCMWBE9.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c01fd0b5f78e08119c436629e5f8673784ac94d054655512754df08d64d6d43
+size 4408

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/1/KT/YSDSLKZM5GHIT0LVUOO03U.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/1/KT/YSDSLKZM5GHIT0LVUOO03U.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52c90ac4951796f8e67cffb56019d9a2243c5fc9818919ea328ccb642aad5afb
+size 4498

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/GB/GKH6OJ1EYZG8FPG6YJJ894.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/GB/GKH6OJ1EYZG8FPG6YJJ894.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e625f9058bf30397907a146ca091f2fa2caa142a312594e8ce8e1d781ab64652
+size 4500

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/GF/7RWIXOCXA66WCDGAO5FOE9.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/GF/7RWIXOCXA66WCDGAO5FOE9.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56fc74f847ff68d9615025a9c5eeb9cd5344f96dcf0378543af509e00c4b4897
+size 4560

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/IE/GB2YQTN1WB5YIVQOL9E0J7.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/IE/GB2YQTN1WB5YIVQOL9E0J7.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4b48968bfbbfe33e670c0ce64a8d12517e20c3c1a50fa0c9a8a8ca814eefaa1
+size 4384

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/3/AR/HG65O18KLYP6IZWIBUPMJA.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/3/AR/HG65O18KLYP6IZWIBUPMJA.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b313ea889fb6ff203597e902282d1b6242775b0723cd70ce201388ce4d77f208
+size 2406

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/CZ/T4BIHD7JI45ZEYJV9LS7OE.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/CZ/T4BIHD7JI45ZEYJV9LS7OE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e910a017ee2ec4862190067b9793b77788b8a1b7f1d6d8509b98706ed69ba2
+size 5278

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/DL/GD6R0YY68O1Y46W5X94D0M.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/DL/GD6R0YY68O1Y46W5X94D0M.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc2f3986a9e28ad0cdc7be058b49646b0ea1080a8dfdb88bf405497e9bd981d
+size 12494

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/KC/2PZAE5XS7O1XBQRLIC3LCN.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/4/KC/2PZAE5XS7O1XBQRLIC3LCN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00f2a4bb7af4c6e38a4a004e62e17df102f5ed81c522ebe0aa7cc3beb494e490
+size 4855

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/90/M9XMMA6GE8M6Z25SNL58NG.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/90/M9XMMA6GE8M6Z25SNL58NG.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:656505f081fe2933e77ba307b183fd8991ff9f29a32cab6696502d4096aa8e70
+size 3653

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/9H/B2ZXKOOZAIKXOD2L71WA16.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/9H/B2ZXKOOZAIKXOD2L71WA16.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2dcc5ff737d5308a50ac861bd40f1a3f4d42467ed00f27bbc187fdde9fd93df
+size 4496

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/BB/6ZCBH0TXT7MA1GYZ3KP3T4.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/5/BB/6ZCBH0TXT7MA1GYZ3KP3T4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39f332eb89c2fb1b1608af821d949bfe450fa981308204c51ef5c361479dd2d3
+size 3746

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/BV/3VAWF8JU6VK9CHPAELJV05.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/BV/3VAWF8JU6VK9CHPAELJV05.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f528e13440f9516794f75197c39a54edc3555b9ce30a5d8b1511466a13069fc5
+size 4384

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/VQ/3N0O08BDR1AFQAC7551HS0.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/VQ/3N0O08BDR1AFQAC7551HS0.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c0da62d783d9f478bda5b042a05976dbdb222fbafb5a744305b319122aa2fce
+size 4019

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/9I/G1549XLYOOE9RXHAGN6N05.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/9I/G1549XLYOOE9RXHAGN6N05.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5b5cd0b399adb5eae21a3cd2c5a298cf664b6e4666e605c3fe07d2f40661bd
+size 4558

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/9S/JA8SOOQY9J2QF3196VF772.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/9S/JA8SOOQY9J2QF3196VF772.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2136d8cd12ec18db41c37e7df816a14d7dfeed2271a6e52d15b80cfdfce3851f
+size 4498

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/CW/WLLSJ5NAY70LFV4ZJ4ANK6.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/CW/WLLSJ5NAY70LFV4ZJ4ANK6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b1c745062c786cae72e47f59aa9a602c143e420d2e2dce989189248a98802f
+size 4384

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/FQ/H0H80Y9FXJHSO2KM0049D8.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/FQ/H0H80Y9FXJHSO2KM0049D8.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38416b60d296c3ef0107a62d23104ebfa5e65dc565882870d55c8b87095fac26
+size 4739

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/JV/WQR2CWSU6A4XN7EMMUCCK8.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/JV/WQR2CWSU6A4XN7EMMUCCK8.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a069c78d04917409a362bbfce5ecd7078f41485a78d38897d83a6a187198b73e
+size 4496

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/WT/EO5RG4F76SSRN1DOZ3I87F.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/8/WT/EO5RG4F76SSRN1DOZ3I87F.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c91e63ec1e0a582289188208cdfe553de8fcca7af69cdb2cea23da61c9c80a6b
+size 4855

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/CQ/3E11NG7CAZA2MAT3YU9MCY.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/CQ/3E11NG7CAZA2MAT3YU9MCY.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22c5ba621cc8a074b78ca62ac0fb0596e6359bedd68dc2b565e1f337d9e47c2a
+size 4384

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/K4/6YNU9QAPHVHQ5UX6DL7KH6.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/K4/6YNU9QAPHVHQ5UX6DL7KH6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c141b771c49712e8d9a59779e354e386306b6944e817d7503cc19a88a94a4c5e
+size 4438

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/LR/JYNV98YZBBN09ZS6VKN8PN.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/9/LR/JYNV98YZBBN09ZS6VKN8PN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a5a597536ced991f335c033fa7eb95a1edff778525fe7f1f06834b3701a3da1
+size 4386

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/A/GX/DOCIDQTE45PIGT7PPR65QQ.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/A/GX/DOCIDQTE45PIGT7PPR65QQ.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07028d79b92f70960104df6372e1b877d4ae3e02ae5aad8cdb97b95df19e4692
+size 4558

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/A/TT/XI6NA7BY4394UPM6UHSYH6.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/A/TT/XI6NA7BY4394UPM6UHSYH6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7310258ddca41f26904c5107ead090828bf942bbedb5591c1e8311bbf615053d
+size 3651

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/48/WANXXH7WJBRT88QBSO22E4.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/48/WANXXH7WJBRT88QBSO22E4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7993ec8bed9f450a672d8576264118f372c69290821eb67f0d8a03dc6a575f88
+size 4474

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/9Y/OXPMAFSWBGT7I2Q27Y6DWH.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/9Y/OXPMAFSWBGT7I2Q27Y6DWH.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f677a6edd025e8fa5fa0c16a80bba003d060aa6bca45a88d4a8aadca16d668f
+size 4382

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/MX/AVW8B6NOFNRAS5KTZX9E57.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/MX/AVW8B6NOFNRAS5KTZX9E57.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:172c29eb3b11225f6941e5c32ef1308f2005267c90af5a8976412db68b24dcd7
+size 2289

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/PQ/LJOKRKJNIHKKUMPMYI781C.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/PQ/LJOKRKJNIHKKUMPMYI781C.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14d85fa1b027b779e033cd142baf2891150f0b68333c5e46f7961a16dfd89abc
+size 4380

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/SB/U6UYIHYT69L415PQJODWJH.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/SB/U6UYIHYT69L415PQJODWJH.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc49ebd65918115406598285d15a1187e3019087394271b2e0e3c06e4e1a351
+size 4386

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/C/J1/GBECFJOFGNEJMABRM27OUK.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/C/J1/GBECFJOFGNEJMABRM27OUK.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43cec2dec3abcca87193519e07863429a80ce87236b5d25ce0f1d94e3305e160
+size 4558

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/C/RN/ASJ9EW8AK9IGKC76JEQNBE.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/C/RN/ASJ9EW8AK9IGKC76JEQNBE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90ef21e9e1990a30437414a99e0d069324b702a23a69eb4445f87f7eb8522d83
+size 4444

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/D/J4/ECKQ1UBO10IDJSEA5QO2AO.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/D/J4/ECKQ1UBO10IDJSEA5QO2AO.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f95ca8efd1164bc2a1392f09f366f01d7772bdfcf656b8e1c6b3d43628df7420
+size 4558

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/D/KX/HTNMRXXRVBV0MRL4RH3QNR.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/D/KX/HTNMRXXRVBV0MRL4RH3QNR.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:658a1e8101c62b0838f1226fdabc169fa46496104c9dc06e1590ef1220dfac1d
+size 4284

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/7P/SF6H5YCV9ZYMNTUXDJXC5C.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/7P/SF6H5YCV9ZYMNTUXDJXC5C.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b085373efadd96200c2c53a2893896a5fe10228b4bdc8a65958d517ea458e58a
+size 4560

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/PG/FB6X8L1XOVREM9AMXICVRH.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/PG/FB6X8L1XOVREM9AMXICVRH.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bfc5f590c072b26301015fdbe749fc3ddd0f0e3c10039ce07878cca00f25313
+size 4446

--- a/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/XS/EK6BTWECW0IPSNMNVW4RXA.uasset
+++ b/Content/__ExternalActors__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/E/XS/EK6BTWECW0IPSNMNVW4RXA.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec6c7ba16c5a72140c2a7e6161fa68d1a5c895d99b7b9d4d00f127d5deb5461e
+size 4997

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/71/563KLTZGWQZHIGE90WTG35.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/71/563KLTZGWQZHIGE90WTG35.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca6eedbaa5cfd335c5098ff03a8dbb3c5126cb5d1a06193638cf7723ff90aa38
+size 2320

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/E6/D40N46JBN3VN4BIF1IRMAN.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/1/E6/D40N46JBN3VN4BIF1IRMAN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e72610bdb0a0e8668a7293f1e729ec6e38ae253ba1a02f64cc0653fecc76e503
+size 2322

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/EB/A04RXFC7QW5KD3BG3W2DC1.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/5/EB/A04RXFC7QW5KD3BG3W2DC1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e2908b96441f11675f2224e72456e92c05292881ed041061410b0c5f50266fc
+size 2320

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/II/PWL8WYD1E68BARP7MY8MGZ.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/8/II/PWL8WYD1E68BARP7MY8MGZ.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a88b877837bfdfa5b990da6dd28470ed923742258a3fe40ab4833fdc9ee2d961
+size 2320

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/6I/MTU1ECLML1SDXJRQ05IZR8.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/B/6I/MTU1ECLML1SDXJRQ05IZR8.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c7f1ed38d5c2bb0042371225cf364734e37ff06cab3f347e2f032a74aa07e1
+size 2326

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/TE/KRYYSQKUL65AKF3VH4TB3D.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/LV_Main/D/TE/KRYYSQKUL65AKF3VH4TB3D.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b8aa761a7c77aa2a8abe1e41b49be05fd911c409d0e226502a1133b17d1ba8c
+size 2322

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/36/3WVOKDA9BGO88KMFSPWIDL.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/0/36/3WVOKDA9BGO88KMFSPWIDL.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbe85be8dfe8e76edbca39bf7cc298720241c3c56fd6f76caf0bc593a69dd243
+size 2338

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/EI/8PSK2BZ5AW6VZ7JXD31JCL.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/2/EI/8PSK2BZ5AW6VZ7JXD31JCL.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f8f87bea7156f3beb9aafa03fa093ef7877e449cec3396458603a6e8f0cf14a
+size 2336

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/B7/BLC9QGLJZCMRC5TVFYV0IU.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/6/B7/BLC9QGLJZCMRC5TVFYV0IU.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f82bf11691eaca7ba390ff358bd562b48587d8476c5955d10cbaf76b7c88f748
+size 2336

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/3C/49LGFHOAZMAOAEW5ZPNHKY.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/3C/49LGFHOAZMAOAEW5ZPNHKY.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88b89d342e6bf80a229c84b14be1c936652d39c005907f49b01f697a5d4aa768
+size 2342

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/ZH/2QK3D3PZ23ZIKZZ3DOI3H4.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/7/ZH/2QK3D3PZ23ZIKZZ3DOI3H4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:194aa5b233d0d75eee0a54770e279b24cd6dd386be661b31233d25146a97f121
+size 2336

--- a/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/N3/XZRAWEXMAESC1HUCR4J4MB.uasset
+++ b/Content/__ExternalObjects__/CombatFrameworkContent/Levels/GameLevels/ThirdPersonMap1/B/N3/XZRAWEXMAESC1HUCR4J4MB.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:babdaad0c2e2b28644577877207bbe48d3d00a3bc36a11185161eb8fedd2f1d2
+size 2338

--- a/Source/CombatFramework/Private/GameFramework/CFR_IGameMode.cpp
+++ b/Source/CombatFramework/Private/GameFramework/CFR_IGameMode.cpp
@@ -4,6 +4,13 @@
 #include "CommonActivatableWidget.h"
 #include "Kismet/GameplayStatics.h"
 
+void ACFR_IGameMode::StartPlay()
+{
+	Super::StartPlay();
+
+	GetWorld()->GetFirstPlayerController()->SetInputMode(FInputModeGameOnly());
+}
+
 void ACFR_IGameMode::PauseGame()
 {
 	const auto World = GetWorld();

--- a/Source/CombatFramework/Private/Widgets/CFR_IPauseMenuWidget.cpp
+++ b/Source/CombatFramework/Private/Widgets/CFR_IPauseMenuWidget.cpp
@@ -30,7 +30,7 @@ void UCFR_IPauseMenuWidget::Resume()
 
 void UCFR_IPauseMenuWidget::ReturnToMainMenu()
 {
-	UE_LOG(LogTemp, Warning, TEXT("Return to Main Menu button in Pause Menu Widget is not yet implemented."));
+	UGameplayStatics::OpenLevel(GetWorld(), TEXT("LV_MainMenu"));
 }
 
 void UCFR_IPauseMenuWidget::ExitGame()

--- a/Source/CombatFramework/Public/GameFramework/CFR_IGameMode.h
+++ b/Source/CombatFramework/Public/GameFramework/CFR_IGameMode.h
@@ -13,6 +13,8 @@ class COMBATFRAMEWORK_API ACFR_IGameMode : public AGameMode
     GENERATED_BODY()
 
 public:
+    void StartPlay() override;
+
     virtual void PauseGame();
 
 protected:


### PR DESCRIPTION
**Summary**
Aquest PR crea dos nous levels:
- `LV_MainMenu` level bàsic amb la lògica simple del menú.
- `LV_Main` copia del nivell que teníem pero en la nostre estructure de carpetes.

Hi ha lògica per a poder transitar d'un Level a l'altre, així com sortir del joc.
També hi ha lògica de `Pause` en in game.

També s'han creat automàticament dues carpetes `__ExternalActors__` i `__ExternalObjects__`. En teoria guarden referencies de tots els actors i objectes dels levels. Això és nou de UE5.0 i es pot deshabilitar si volem. En principi ajuda a l'hora de fer servir git ja que ens permet modificar un mateix level sense que això afecti a un merge, sempre i quant no modifiquem el mateix objecte o actor.
Més info:
https://dev.epicgames.com/documentation/en-us/unreal-engine/world-partition-in-unreal-engine?application_version=5.0
https://dev.epicgames.com/documentation/en-us/unreal-engine/one-file-per-actor-in-unreal-engine?application_version=5.0