### PR TITLE
DamageExecution class. LightCombo applying damage.

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -11,5 +11,10 @@ NetIndexFirstBitSegment=16
 +GameplayTagList=(Tag="Combo.CanCombo",DevComment="The actor is in a time interval when it can combo to next ability given the right input.")
 +GameplayTagList=(Tag="Combo.CanJumpToComboSection",DevComment="The character is in a time interval where it can jump to next combo section immediatly, given the right input..")
 +GameplayTagList=(Tag="Combo.ContinueCombo",DevComment="The actor received the correct input to continue with a combo.")
++GameplayTagList=(Tag="GameplayEvent.Montage",DevComment="Generic event fired by a montage.")
++GameplayTagList=(Tag="GameplayEvent.Montage.Melee",DevComment="Used for montage events referring to melee actions.")
++GameplayTagList=(Tag="GameplayEvent.Montage.Melee.First",DevComment="")
++GameplayTagList=(Tag="GameplayEvent.Montage.Melee.Second",DevComment="")
++GameplayTagList=(Tag="GameplayEvent.Montage.Melee.Third",DevComment="")
 +GameplayTagList=(Tag="Hitboxes.Weapon.Front",DevComment="")
 

--- a/Content/CombatFrameworkContent/Characters/Player/Animations/Montages/AM_LightCombo.uasset
+++ b/Content/CombatFrameworkContent/Characters/Player/Animations/Montages/AM_LightCombo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4baa61e7576036d6d3eb0655d65929542c6365778764a6259fe3aa5d9fbe68b3
-size 23159
+oid sha256:5abd42c8f82cfe4d6a70ab8b0661ad96bd5dbca69f26181f0e709e1f65b6eb18
+size 24898

--- a/Content/CombatFrameworkContent/Characters/Player/BP_PlayerCharacter.uasset
+++ b/Content/CombatFrameworkContent/Characters/Player/BP_PlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ec73a10a7a898ac4bc0406e30e49a8714709cfcbf79368eaaba4b6d81f3d713
-size 38730
+oid sha256:a77969722ae96116cbca9244c224548ae621abbf6203ecb6a4c775b1d08176ff
+size 48751

--- a/Content/CombatFrameworkContent/GAS/Abilities/GA_LightAttack.uasset
+++ b/Content/CombatFrameworkContent/GAS/Abilities/GA_LightAttack.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be755acb2184e1c5ff10ebea1a655c4e59c1ab76056cfc454c72fa038a83634d
-size 6272
+oid sha256:268fd874dfbba77d8e079db6cf1d7234efdfe619bedd22334dd76b61d653a9ee
+size 7145

--- a/Content/CombatFrameworkContent/GAS/GameplayEffects/GE_Damage.uasset
+++ b/Content/CombatFrameworkContent/GAS/GameplayEffects/GE_Damage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc27cdf9210f034d828d8beaa47a3dbcf4df8f3f353c84a58832ac1169f39971
+size 6436

--- a/Content/CombatFrameworkContent/GAS/GameplayEffects/GE_SimpleDamage.uasset
+++ b/Content/CombatFrameworkContent/GAS/GameplayEffects/GE_SimpleDamage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff9ae22eca956958a09650e7a1ca2c3298beb9e9a5cdfbaa6dee329d7472c018
+size 13030

--- a/Source/CombatFramework/CombatFramework.Build.cs
+++ b/Source/CombatFramework/CombatFramework.Build.cs
@@ -8,7 +8,7 @@ public class CombatFramework : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-		PublicDependencyModuleNames.AddRange(new string[] { "CommonUI", "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "EnhancedInput", "GameplayAbilities", "UMG" });
+		PublicDependencyModuleNames.AddRange(new string[] { "CommonUI", "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "EnhancedInput", "GameplayAbilities", "UMG", "AIModule" });
 		PrivateDependencyModuleNames.AddRange(new string[] { "GameplayTags", "GameplayTasks" });
 	}
 }

--- a/Source/CombatFramework/Private/AbilitySystem/CFR_AttributeSet.cpp
+++ b/Source/CombatFramework/Private/AbilitySystem/CFR_AttributeSet.cpp
@@ -19,7 +19,7 @@ UCFR_AttributeSet::UCFR_AttributeSet()
 	InitStrength(10.0f);
 }
 
-void UCFR_AttributeSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty> &OutLifetimeProps) const
+void UCFR_AttributeSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	DOREPLIFETIME_CONDITION_NOTIFY(UCFR_AttributeSet, CurrentHealth, COND_None, REPNOTIFY_Always);
 	DOREPLIFETIME_CONDITION_NOTIFY(UCFR_AttributeSet, MaxHealth, COND_None, REPNOTIFY_Always);
@@ -28,7 +28,7 @@ void UCFR_AttributeSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty> &Ou
 	DOREPLIFETIME_CONDITION_NOTIFY(UCFR_AttributeSet, Strength, COND_None, REPNOTIFY_Always);
 }
 
-void UCFR_AttributeSet::PreAttributeChange(const FGameplayAttribute &Attribute, float &NewValue)
+void UCFR_AttributeSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
 {
 	Super::PreAttributeChange(Attribute, NewValue);
 
@@ -50,13 +50,13 @@ void UCFR_AttributeSet::PreAttributeChange(const FGameplayAttribute &Attribute, 
 	}
 }
 
-void UCFR_AttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData &Data)
+void UCFR_AttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
 {
 	Super::PostGameplayEffectExecute(Data);
 
 	FGameplayEffectContextHandle Context = Data.EffectSpec.GetContext();
-	const UAbilitySystemComponent *SourceASC = Context.GetOriginalInstigatorAbilitySystemComponent();
-	const FGameplayTagContainer &SourceTags = *Data.EffectSpec.CapturedSourceTags.GetAggregatedTags();
+	const UAbilitySystemComponent* SourceASC = Context.GetOriginalInstigatorAbilitySystemComponent();
+	const FGameplayTagContainer& SourceTags = *Data.EffectSpec.CapturedSourceTags.GetAggregatedTags();
 
 	if (Data.EvaluatedData.Attribute == GetDamageAttribute() &&
 		SourceASC && SourceASC->AbilityActorInfo.IsValid() && SourceASC->AbilityActorInfo->AvatarActor.IsValid() &&

--- a/Source/CombatFramework/Private/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.cpp
+++ b/Source/CombatFramework/Private/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.cpp
@@ -2,7 +2,9 @@
 
 
 #include "AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.h"
+#include "Characters/CFR_CharacterBase.h"
 
+#include "AbilitySystemComponent.h"
 #include "AbilitySystem/AbilityTasks/CFR_PlayMontageAndWaitForEvent.h"
 
 bool UCFR_GA_PlayMontage::CanActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayTagContainer* SourceTags, const FGameplayTagContainer* TargetTags, OUT FGameplayTagContainer* OptionalRelevantTags) const
@@ -36,5 +38,27 @@ void UCFR_GA_PlayMontage::OnMontageFinished(FGameplayTag EventTag, FGameplayEven
 
 void UCFR_GA_PlayMontage::OnReceivedEvent(FGameplayTag EventTag, FGameplayEventData EventData)
 {
-	BP_OnReceivedEvent(EventTag, EventData);
+	AActor* OwnerActor = GetOwningActorFromActorInfo();
+	const IAbilitySystemInterface* AbilitySystemInterface = Cast<IAbilitySystemInterface>(OwnerActor);
+	if (AbilitySystemInterface != nullptr)
+	{
+		UAbilitySystemComponent* OwnerASC = AbilitySystemInterface->GetAbilitySystemComponent();
+		const ACFR_CharacterBase* TargetCharacter = Cast<ACFR_CharacterBase>(EventData.Target);
+		UAbilitySystemComponent* TargetASC = TargetCharacter ? TargetCharacter->GetAbilitySystemComponent() : nullptr;
+
+		if (EffectsToApply.Contains(EventTag) && TargetASC)
+		{
+			TSubclassOf<UGameplayEffect> GameplayEffectToApply = *EffectsToApply.Find(EventTag);
+			// TODO: Remove hardcoded 1.0f. CharacterBase should have the level.
+			FGameplayEffectSpecHandle GameplayEffectSpecHandle = MakeOutgoingGameplayEffectSpec(GameplayEffectToApply, 1.0f);
+
+			FGameplayEffectContextHandle EffectContext = MakeEffectContext(GetCurrentAbilitySpecHandle(), GetCurrentActorInfo());
+			FGameplayEffectSpec* GameplayEffectSpec = GameplayEffectSpecHandle.Data.Get();
+			GameplayEffectSpec->SetContext(EffectContext);
+
+			OwnerASC->ApplyGameplayEffectSpecToTarget(*GameplayEffectSpec, TargetASC);
+		}
+
+		BP_OnReceivedEvent(EventTag, EventData);
+	}
 }

--- a/Source/CombatFramework/Private/AbilitySystem/GameplayEffects/CFR_Execution_Damage.cpp
+++ b/Source/CombatFramework/Private/AbilitySystem/GameplayEffects/CFR_Execution_Damage.cpp
@@ -1,0 +1,64 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/GameplayEffects/CFR_Execution_Damage.h"
+#include "AbilitySystem/CFR_AttributeSet.h"
+
+struct CFR_DamageStatics
+{
+	DECLARE_ATTRIBUTE_CAPTUREDEF(Strength)
+	DECLARE_ATTRIBUTE_CAPTUREDEF(Damage)
+
+	CFR_DamageStatics()
+	{
+		DEFINE_ATTRIBUTE_CAPTUREDEF(UCFR_AttributeSet, Strength, Source, true);
+		DEFINE_ATTRIBUTE_CAPTUREDEF(UCFR_AttributeSet, Damage, Source, true);
+	}
+};
+
+static const CFR_DamageStatics& DamageStatics()
+{
+	static CFR_DamageStatics DamageStatics;
+	return DamageStatics;
+}
+
+UCFR_Execution_Damage::UCFR_Execution_Damage()
+{
+	RelevantAttributesToCapture.Add(DamageStatics().StrengthDef);
+	RelevantAttributesToCapture.Add(DamageStatics().DamageDef);
+}
+
+void UCFR_Execution_Damage::Execute_Implementation(const FGameplayEffectCustomExecutionParameters& ExecutionParams, FGameplayEffectCustomExecutionOutput& OutExecutionOutput) const
+{
+	// Extract ASC.
+	const UAbilitySystemComponent* TargetASC = ExecutionParams.GetTargetAbilitySystemComponent();
+	const UAbilitySystemComponent* SourceASC = ExecutionParams.GetSourceAbilitySystemComponent();
+
+	// Extract avatar actors.
+	AActor* TargetActor = TargetASC ? TargetASC->GetAvatarActor() : nullptr;
+	AActor* SourceActor = SourceASC ? SourceASC->GetAvatarActor() : nullptr;
+
+	const FGameplayEffectSpec& Spec = ExecutionParams.GetOwningSpec();
+
+	// Extract tags.
+	const FGameplayTagContainer* SourceTags = Spec.CapturedSourceTags.GetAggregatedTags();
+	const FGameplayTagContainer* TargetTags = Spec.CapturedTargetTags.GetAggregatedTags();
+
+	// TODO: Checks (ex: if invulnerable or already dead, do not apply damage and return).
+
+	FAggregatorEvaluateParameters EvaluationParameters;
+	EvaluationParameters.TargetTags = TargetTags;
+	EvaluationParameters.SourceTags = SourceTags;
+
+	float Strength = 0.0f;
+	ExecutionParams.AttemptCalculateCapturedAttributeMagnitude(DamageStatics().StrengthDef, EvaluationParameters, Strength);
+
+	// TODO: Damage calculation function. Ex: GE BaseDamage + Strength * StrengthFactor - TargetDef.
+	float FinalDamage = 0.0f;
+	FinalDamage = Strength;
+
+	if (FinalDamage > 0.0f)
+	{
+		OutExecutionOutput.AddOutputModifier(FGameplayModifierEvaluatedData(CFR_DamageStatics().DamageProperty, EGameplayModOp::Additive, FinalDamage));
+	}
+}

--- a/Source/CombatFramework/Private/Characters/CFR_AICharacter.cpp
+++ b/Source/CombatFramework/Private/Characters/CFR_AICharacter.cpp
@@ -14,6 +14,11 @@ ACFR_AICharacter::ACFR_AICharacter()
 	AttributeSet = CreateDefaultSubobject<UCFR_AttributeSet>("AttributeSet");
 }
 
+FGenericTeamId ACFR_AICharacter::GetGenericTeamId() const
+{
+	return FGenericTeamId(1);
+}
+
 void ACFR_AICharacter::BeginPlay()
 {
 	Super::BeginPlay();

--- a/Source/CombatFramework/Private/Characters/CFR_PlayerCharacter.cpp
+++ b/Source/CombatFramework/Private/Characters/CFR_PlayerCharacter.cpp
@@ -67,6 +67,11 @@ void ACFR_PlayerCharacter::HandleHealthChanged(const FOnAttributeChangeData& InD
 	Super::HandleHealthChanged(InData);
 }
 
+FGenericTeamId ACFR_PlayerCharacter::GetGenericTeamId() const
+{
+	return FGenericTeamId(0);
+}
+
 void ACFR_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);

--- a/Source/CombatFramework/Private/Characters/CFR_PlayerCharacter.cpp
+++ b/Source/CombatFramework/Private/Characters/CFR_PlayerCharacter.cpp
@@ -67,11 +67,6 @@ void ACFR_PlayerCharacter::HandleHealthChanged(const FOnAttributeChangeData& InD
 	Super::HandleHealthChanged(InData);
 }
 
-FGenericTeamId ACFR_PlayerCharacter::GetGenericTeamId() const
-{
-	return FGenericTeamId(0);
-}
-
 void ACFR_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
@@ -125,6 +120,11 @@ void ACFR_PlayerCharacter::PossessedBy(AController* NewController)
 void ACFR_PlayerCharacter::OnRep_PlayerState()
 {
 	InitAbilitySystemInfo();
+}
+
+FGenericTeamId ACFR_PlayerCharacter::GetGenericTeamId() const
+{
+	return FGenericTeamId(0);
 }
 
 void ACFR_PlayerCharacter::InitAbilitySystemInfo()

--- a/Source/CombatFramework/Private/Notifies/CFR_ANS_ActivateHitbox.cpp
+++ b/Source/CombatFramework/Private/Notifies/CFR_ANS_ActivateHitbox.cpp
@@ -15,7 +15,9 @@ void UCFR_ANS_ActivateHitbox::NotifyBegin(USkeletalMeshComponent* MeshComp, UAni
 		UCFR_HitboxComponent* Hitbox = HitboxesManagerComp->GetHitboxByTag(HitboxTag);
 		if (Hitbox)
 		{
-			Hitbox->ActivateHitbox(true);
+			UE_LOG(LogTemp, Warning, TEXT("ACTIVATE!"));
+			Hitbox->SetEffectTag(EffectTag);
+			Hitbox->ActivateHitbox();
 		}
 	}
 }
@@ -30,7 +32,9 @@ void UCFR_ANS_ActivateHitbox::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimS
 		UCFR_HitboxComponent* Hitbox = HitboxesManagerComp->GetHitboxByTag(HitboxTag);
 		if (Hitbox)
 		{
-			Hitbox->ActivateHitbox(false);
+			UE_LOG(LogTemp, Warning, TEXT("DEACTIVATE!"));
+			Hitbox->DeactivateHitbox();
+			Hitbox->SetEffectTag(FGameplayTag());
 		}
 	}
 }

--- a/Source/CombatFramework/Public/AbilitySystem/CFR_AttributeSet.h
+++ b/Source/CombatFramework/Public/AbilitySystem/CFR_AttributeSet.h
@@ -46,6 +46,11 @@ public:
 	FGameplayAttributeData Strength;
 	ATTRIBUTE_ACCESSORS(UCFR_AttributeSet, Strength);
 
+	/** Damage is a 'temporary' attribute used by the DamageExecution to calculate final damage, which then turns into -Health */
+	UPROPERTY(BlueprintReadOnly, Category = "Damage")
+	FGameplayAttributeData Damage;
+	ATTRIBUTE_ACCESSORS(UCFR_AttributeSet, Damage);
+
 	UFUNCTION()
 	void OnRep_CurrentHealth(const FGameplayAttributeData OldCurrentHealth) const;
 

--- a/Source/CombatFramework/Public/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.h
+++ b/Source/CombatFramework/Public/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.h
@@ -48,4 +48,8 @@ protected:
 	// The Tag for the montage to wait for.
 	UPROPERTY(EditAnywhere)
 	FGameplayTagContainer EventTagContainer;
+
+	// Effects to apply to target actor when the events are received.
+	UPROPERTY(EditDefaultsOnly)
+	TMap<FGameplayTag, TSubclassOf<UGameplayEffect>> EffectsToApply;
 };

--- a/Source/CombatFramework/Public/AbilitySystem/GameplayEffects/CFR_Execution_Damage.h
+++ b/Source/CombatFramework/Public/AbilitySystem/GameplayEffects/CFR_Execution_Damage.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayEffectExecutionCalculation.h"
+
+#include "CFR_Execution_Damage.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class UCFR_Execution_Damage : public UGameplayEffectExecutionCalculation
+{
+	GENERATED_BODY()
+	
+	UCFR_Execution_Damage();
+	void Execute_Implementation(const FGameplayEffectCustomExecutionParameters& ExecutionParams, FGameplayEffectCustomExecutionOutput& OutExecutionOutput) const override;
+};

--- a/Source/CombatFramework/Public/Characters/CFR_AICharacter.h
+++ b/Source/CombatFramework/Public/Characters/CFR_AICharacter.h
@@ -14,6 +14,8 @@ class COMBATFRAMEWORK_API ACFR_AICharacter : public ACFR_CharacterBase
 public:
 	ACFR_AICharacter();
 
+	virtual FGenericTeamId GetGenericTeamId() const override;
+
 protected:
 	void BeginPlay() override;
 	void InitAbilitySystemInfo() override;

--- a/Source/CombatFramework/Public/Characters/CFR_CharacterBase.h
+++ b/Source/CombatFramework/Public/Characters/CFR_CharacterBase.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "AbilitySystemInterface.h"
 #include "GameFramework/Character.h"
+#include "GenericTeamAgentInterface.h"
 #include "CFR_CharacterBase.generated.h"
 
 class UAbilitySystemComponent;
@@ -12,7 +13,7 @@ class UAttributeSet;
 struct FOnAttributeChangeData;
 
 UCLASS()
-class COMBATFRAMEWORK_API ACFR_CharacterBase : public ACharacter, public IAbilitySystemInterface
+class COMBATFRAMEWORK_API ACFR_CharacterBase : public ACharacter, public IAbilitySystemInterface, public IGenericTeamAgentInterface
 {
 	GENERATED_BODY()
 

--- a/Source/CombatFramework/Public/Characters/CFR_PlayerCharacter.h
+++ b/Source/CombatFramework/Public/Characters/CFR_PlayerCharacter.h
@@ -23,6 +23,7 @@ public:
 	void PossessedBy(AController* NewController) override;
 	/* Called on client by the server after PlayerState (and hence, our ability system component) has been initialized. */
 	void OnRep_PlayerState() override;
+	virtual FGenericTeamId GetGenericTeamId() const override;
 
 	/** Returns CameraBoom subobject **/
 	FORCEINLINE class USpringArmComponent* GetCameraBoom() const { return CameraBoom; }

--- a/Source/CombatFramework/Public/Components/CFR_HitboxComponent.h
+++ b/Source/CombatFramework/Public/Components/CFR_HitboxComponent.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Components/SceneComponent.h"
+#include "GameplayTagContainer.h"
 #include "CFR_HitboxComponent.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCFR_HitboxOverlapDelegate, class AActor*, HitActor);
@@ -36,15 +37,26 @@ private:
 		bool bFromSweep,
 		const FHitResult& SweepResult);
 public:	
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-
 	/** Activate hitbox for detecting overlaps and set collision preset to dodgeable. */
 	UFUNCTION(BlueprintCallable)
-	void ActivateHitbox(bool bActivateEffect);
+	void ActivateHitbox();
 
 	/** Deactivate hitbox. */
 	UFUNCTION(BlueprintCallable)
 	void DeactivateHitbox();
+
+	/** Set the event tag to be sent when the hitbox hits a target actor. */
+	UFUNCTION(BlueprintCallable)
+	void SetEffectTag(FGameplayTag Tag);
+
+	/** Get the event tag to be sent when the hitbox hits a target actor. */
+
+	UFUNCTION(BlueprintCallable)
+	FGameplayTag GetEffectTag() const;
+
+protected:
+	// TODO: Will received a list of the hit actors. Will send a unique event for all the hit actors, with the list of actors as payload.
+	void SendCollisionEvents(AActor* TargetActor);
 
 public:
 	FCFR_HitboxOverlapDelegate OnHitboxOverlap;
@@ -53,5 +65,8 @@ protected:
 	/** All shapes forming the hitbox component. */
 	UPROPERTY()
 	TArray<UShapeComponent*> Shapes;
+
+	/* EffectTag to apply when hitting. */
+	FGameplayTag EffectTag;
 
 };

--- a/Source/CombatFramework/Public/Notifies/CFR_ANS_ActivateHitbox.h
+++ b/Source/CombatFramework/Public/Notifies/CFR_ANS_ActivateHitbox.h
@@ -22,4 +22,7 @@ public:
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FGameplayTag HitboxTag;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FGameplayTag EffectTag;
 };


### PR DESCRIPTION
- El light combo ja fa mal al peseante.
- S'han afegit tags relacionades amb els eventos que es tiren durant els combos. Aquests eventos es gestionen a la gameplay ability i van mapejats a un efecte (en un futur ha de ser una array d'efectes amb diferents EventData).
- S'ha afegit ExecutionDamage com a classe de càlcul de damage.
- S'ha afegit Damage com a atribut. Primer es canvia el Damage amb el gameplay effect i dspr, el PostAttributeChanged canvia la health en funció del damage rebut.
- Per default els hitboxes només envien eventos en colisions contra un Agent hostile (a modificar en un futur).