### PR TITLE
Payload event data

### DIFF
--- a/Content/CombatFrameworkContent/GAS/Abilities/GA_LightAttack.uasset
+++ b/Content/CombatFrameworkContent/GAS/Abilities/GA_LightAttack.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:268fd874dfbba77d8e079db6cf1d7234efdfe619bedd22334dd76b61d653a9ee
-size 7145
+oid sha256:d56200a2a6a0d884139a7e561819f8e703298d2cba04d5b1017d1884b94fcf1b
+size 7915

--- a/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack1.uasset
+++ b/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a609610a10bd8ebcdfacd47814b9d7c13bfe5e5f1ca5299f92daa2b4bcaa5d66
+size 1629

--- a/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack2.uasset
+++ b/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack2.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:495c48fd87da0b3e9cc0ed74f19dfc9a3e86c633bbcbdc395af146547bfb269d
+size 1629

--- a/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack3.uasset
+++ b/Content/CombatFrameworkContent/GAS/EventData/DA_LightAttack3.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:974dfd38162e05a4fceccc308fc65fa6b4dd8dd9b3fc1b1723b5fe1862d320db
+size 1629

--- a/Source/CombatFramework/Private/AbilitySystem/CFR_AbilitySystemGlobals.cpp
+++ b/Source/CombatFramework/Private/AbilitySystem/CFR_AbilitySystemGlobals.cpp
@@ -1,0 +1,14 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/CFR_AbilitySystemGlobals.h"
+
+FGameplayEffectContext* UCFR_AbilitySystemGlobals::AllocGameplayEffectContext() const
+{
+	return new FCFR_GameplayEffectContext();
+}
+
+bool FCFR_GameplayEffectContext::NetSerialize(FArchive& Ar, UPackageMap* Map, bool& bOutSuccess)
+{
+	return Super::NetSerialize(Ar, Map, bOutSuccess);
+}

--- a/Source/CombatFramework/Public/AbilitySystem/CFR_AbilitySystemGlobals.h
+++ b/Source/CombatFramework/Public/AbilitySystem/CFR_AbilitySystemGlobals.h
@@ -1,0 +1,67 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystemGlobals.h"
+#include "GameplayEffectTypes.h"
+#include "CFR_AbilitySystemGlobals.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class COMBATFRAMEWORK_API UCFR_AbilitySystemGlobals : public UAbilitySystemGlobals
+{
+	GENERATED_BODY()
+	
+public:
+	static UCFR_AbilitySystemGlobals& UCFRGet()
+	{
+		return dynamic_cast<UCFR_AbilitySystemGlobals&>(Get());
+	}
+
+	FGameplayEffectContext* AllocGameplayEffectContext() const override;
+};
+
+USTRUCT(BlueprintType)
+struct COMBATFRAMEWORK_API FCFR_GameplayEffectContext : public FGameplayEffectContext
+{
+	GENERATED_USTRUCT_BODY()
+
+public:
+	UScriptStruct* GetScriptStruct() const override
+	{
+		return FCFR_GameplayEffectContext::StaticStruct();
+	}
+
+	FCFR_GameplayEffectContext* Duplicate() const override
+	{
+		FCFR_GameplayEffectContext* NewContext = new FCFR_GameplayEffectContext();
+		*NewContext = *this;
+		NewContext->AddActors(Actors);
+		if (GetHitResult())
+		{
+			// Does a deep copy of the hit result
+			NewContext->AddHitResult(*GetHitResult(), true);
+		}
+
+		return NewContext;
+	}
+
+	bool NetSerialize(FArchive& Ar, class UPackageMap* Map, bool& bOutSuccess) override;
+
+public:
+	// Payload. Object with the EventDataAsset.
+	UObject* OptionalObject = nullptr;
+};
+
+template<>
+struct TStructOpsTypeTraits<FCFR_GameplayEffectContext> : public TStructOpsTypeTraitsBase2<FCFR_GameplayEffectContext>
+{
+	enum
+	{
+		WithNetSerializer = true,
+		WithCopy = true		// Necessary so that TSharedPtr<FHitResult> Data is copied around
+	};
+};

--- a/Source/CombatFramework/Public/AbilitySystem/CFR_EventDataPayloads.h
+++ b/Source/CombatFramework/Public/AbilitySystem/CFR_EventDataPayloads.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayEffectTypes.h"
+
+#include "CFR_EventDataPayloads.generated.h"
+
+
+UCLASS()
+class UCFR_EventDataAsset : public UPrimaryDataAsset
+{
+	GENERATED_BODY()
+
+protected:
+	UPROPERTY()
+	FGameplayTag EventTag;
+
+public:
+	FGameplayTag GetEventTag() { return EventTag; }
+};
+
+USTRUCT(BlueprintType)
+struct FCFR_EffectContextContainer
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	TSubclassOf<UGameplayEffect> EffectToApply;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	UCFR_EventDataAsset* Payload = nullptr;
+};
+
+UCLASS(BlueprintType)
+class UCFR_DamageEventDataAsset : public UCFR_EventDataAsset
+{
+	GENERATED_BODY()
+
+public:
+	// TODO: Table information about the damage to apply.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	float Damage;
+};

--- a/Source/CombatFramework/Public/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.h
+++ b/Source/CombatFramework/Public/AbilitySystem/GameplayAbilities/CFR_GA_PlayMontage.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "AbilitySystem/CFR_GameplayAbility.h"
+#include "AbilitySystem/CFR_EventDataPayloads.h"
 #include "CFR_GA_PlayMontage.generated.h"
 
 /**
@@ -51,5 +52,5 @@ protected:
 
 	// Effects to apply to target actor when the events are received.
 	UPROPERTY(EditDefaultsOnly)
-	TMap<FGameplayTag, TSubclassOf<UGameplayEffect>> EffectsToApply;
+	TMap<FGameplayTag, FCFR_EffectContextContainer> EffectsToApply;
 };


### PR DESCRIPTION
- S'ha fet subclass del GameplayEffectContext per incloure Damage de les habilitats en base a DataAssets. A expandir en un futur amb més informació sobre el tipus de Damage.
- Es poden crear data assets per enviar com a payload (de moment només n'hi ha el de Damage).